### PR TITLE
Update loops.md - Fix for code snipper when array elements is string with space in between

### DIFF
--- a/lessons/loops.md
+++ b/lessons/loops.md
@@ -21,7 +21,7 @@ friends=(Kyle Marc Jem "Brian Holt" Sarah)
 
 echo My second friend is ${friends[1]}
 
-for friend in ${friends[*]}
+for friend in "${friends[*]}"
 do
     echo friend: $friend
 done


### PR DESCRIPTION
Change in this PR is to fix the issue when one of the array elements has space ("Brian Holt"  in the code snippet), it is getting getting split as separate elements while looping over and printing the friends names.